### PR TITLE
Fixed Firefox text overflow issue

### DIFF
--- a/examples/basic/index.html
+++ b/examples/basic/index.html
@@ -24,6 +24,10 @@
 				text-transform: uppercase;
 			}
 
+			p {
+				color: midnightblue;
+			}
+
 			.hermes {
 				position: relative;
 			}

--- a/examples/basic/main.js
+++ b/examples/basic/main.js
@@ -64,6 +64,8 @@ function render (state) {
 				onChangeValue={onChangeValue}
 				onSelectSuggestion={onSelectSuggestion}
 			/>
+
+			<p>Hermes is a confirgurable React component for composing messages.</p>
 		</div>
 	), el);
 }

--- a/src/hermes.jsx
+++ b/src/hermes.jsx
@@ -191,8 +191,14 @@ module.exports = createReactClass({
 				this.input.textContent = zws;
 			}
 
-			// Set the new seleciton
-			selection(this.input, this.props.selection);
+			// Set the new selection
+			selection(this.input, {
+				start: this.props.selection.start,
+				end: this.props.selection.end,
+				// at start false here because FF will set the selection to the
+				// start of the next text element when setting to the end of a line
+				atStart: false
+			});
 		} else if (valChanged) {
 			// If we selected a suggestion, but it was
 			// of the same length, then the selection
@@ -359,7 +365,7 @@ module.exports = createReactClass({
 	updateValue: function () {
 		// Remove the zero width space if thats all thats there
 		// @NOTE search this file for "zws" to see where its added
-		var cleanInput = this.input.textContent.replace(zws, '');
+		var cleanInput = cleanSpaces(this.input.textContent);
 		if (cleanInput !== this.props.value) {
 			ifPropCall(this.props, 'onChangeValue', cleanInput);
 		}
@@ -394,4 +400,10 @@ function atEndOfNode (node) {
 	text = text.replace(zws, '');
 
 	return sel.end === sel.start && sel.end === text.length;
+}
+
+var rZws = new RegExp(zws, 'g');
+var rSp = new RegExp(' ', 'g');
+function cleanSpaces (val) {
+	return val.replace(rZws, '').replace(rSp, nbsp);
 }


### PR DESCRIPTION
When the line ends in a space, firefox would overflow the text selection into the next element.  This checks for that, and ends with a zero width space character.