### PR TITLE
Bump @streammedev/flyout

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
   },
   "dependencies": {
     "@streammedev/flux-store": "^1.0.1",
-    "@streammedev/flyout": "0.0.5",
+    "@streammedev/flyout": "0.0.6",
     "create-react-class": "^15.6.0",
-    "prop-types": "^15.5.10",
     "debounce": "^1.0.0",
+    "prop-types": "^15.5.10",
     "selection-range": "^1.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Projects using Hermes cannot build:
```
/Users/nick/Development/StreamMe/nicks-mounts/communities/services/communities/node_modules/@streammedev/hermes/node_modules/@streammedev/flyout/lib/toggle.js:72
	element: _react2.default.PropTypes.string,
	                                  ^

TypeError: Cannot read property 'string' of undefined
```